### PR TITLE
ci: test Python 3.11, 3.12, and 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Test all supported Python versions under Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/justfile
+++ b/justfile
@@ -14,7 +14,6 @@ qa:
 
 # Run all the tests for all the supported Python versions
 testall:
-    uv run --python=3.10 --extra test pytest
     uv run --python=3.11 --extra test pytest
     uv run --python=3.12 --extra test pytest
     uv run --python=3.13 --extra test pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = {text = "MIT"}
 dependencies = [
   "typer"
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## Summary
- test workflow against Python 3.11, 3.12, and 3.13
- require Python 3.11+ in project metadata
- drop Python 3.10 from local test script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c57d46e900832e8391dd55d40ed934