### PR TITLE
feat(config, cli): add `cgpt set` and default model/mode support (issue #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Store it via CLI:
 
 ```bash
 cgpt login
+cgpt where   # show config path
 ```
 
 Config path:
@@ -43,6 +44,31 @@ If no config is found, `OPENAI_API_KEY` env var is used:
 ```bash
 export OPENAI_API_KEY="your-key"   # macOS/Linux
 setx OPENAI_API_KEY "your-key"     # Windows PowerShell
+```
+
+
+
+## Configure Defaults
+
+Use `cgpt set` to configure defaults like model and mode:
+
+```bash
+# Set a default model
+cgpt set --model gpt-4o
+
+# Set default mode (responses | chat)
+cgpt set --mode responses
+
+# Set both model and mode at once
+cgpt set --model gpt-4o-mini --mode chat
+```
+
+Example config file:
+
+```toml
+api_key       = "sk-...redacted..."
+default_model = "gpt-4o-mini"
+default_mode  = "chat"
 ```
 
 

--- a/src/cgpt/config.py
+++ b/src/cgpt/config.py
@@ -10,12 +10,15 @@ Configuration management for the `cgpt` CLI.
 - Falls back to the environment variable OPENAI_API_KEY if no config is found.
 """
 
+import io
+import json
 import os
 import sys
+import time
 import tomllib
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Optional, Mapping
+from typing import Optional, Mapping, Any
 
 APP_NAME = "cgpt"
 CONFIG_FILE = "config.toml"
@@ -78,6 +81,39 @@ def config_path() -> Path:
     return config_dir() / CONFIG_FILE
 
 
+def _atomic_write_text(path: Path, data: str) -> None:
+    """Atomically write `data` to `path`."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp-{int(time.time() * 1000)}")
+    with open(tmp, "w", encoding="utf-8", newline="\n") as file:
+        file.write(data)
+        file.flush()
+        os.fsync(file.fileno())
+    os.replace(tmp, path)
+
+
+def _dump_toml(data: Mapping[str, Any]) -> str:
+    """Serialize a (flat) mapping to TOML using a minimal, safe writer.
+
+    Supports str/bool/int/float scalars. For anything else, values are
+    JSON-encoded into a quoted TOML string to remain valid.
+    """
+    buf = io.StringIO()
+    for key, value in data.items():
+        if isinstance(value, str):
+            buf.write(f'{key} = "{_toml_escape(value)}"\n')
+        elif isinstance(value, bool):
+            buf.write(f"{key} = {'true' if value else 'false'}\n")
+        elif isinstance(value, (int, float)):
+            buf.write(f"{key} = {value}\n")
+        else:
+            # Store unknown types as JSON inside a TOML string
+            buf.write(
+                f'{key} = "{_toml_escape(json.dumps(value, ensure_ascii=False))}"\n'
+            )
+    return buf.getvalue()
+
+
 def _normalize_str(value: Optional[str]) -> Optional[str]:
     """Normalize a string field: treat empty/whitespace-only string as None."""
     if value is None:
@@ -87,32 +123,55 @@ def _normalize_str(value: Optional[str]) -> Optional[str]:
 
 
 def load_config() -> Config:
-    """Load config values from TOML file, if it exists.
+    """Load configuration from ``config_path()`` (TOML).
+
+    Behavior:
+    - If the file does not exist → return an empty/default ``Config()``.
+    - If the file is valid TOML → return a ``Config`` populated from keys.
+    - If the file is malformed → rename it to ``.bad-<timestamp>`` and return
+      an empty/default ``Config()`` (no crash).
 
     Returns:
-        Config: A Config object with values populated or None if missing.
+        Config: Always a Config instance. Missing/invalid values become ``None``.
     """
-    path = config_path()
+    path: Path = config_path()
     if not path.exists():
         return Config()
 
-    with path.open("rb") as f:
-        data = tomllib.load(f)
+    try:
+        with path.open("rb") as f:
+            data: dict = tomllib.load(f)
+    except tomllib.TOMLDecodeError:
+        # Preserve the broken file for debugging, then fall back to defaults.
+        try:
+            path.rename(path.with_suffix(path.suffix + f".bad-{int(time.time())}"))
+        except OSError:
+            # If we can't move it, still continue with defaults.
+            pass
+        return Config()
+    except OSError:
+        # IO errors: treat as missing and return defaults.
+        return Config()
+
+    def _get_str(key: str) -> Optional[str]:
+        val = data.get(key)
+        return val if isinstance(val, str) and val.strip() else None
 
     return Config(
-        api_key=data.get(KEY_API) or None,
-        base_url=data.get(KEY_BASE_URL) or None,
-        default_model=data.get(KEY_DEFAULT_MODEL) or None,
-        default_mode=data.get(KEY_DEFAULT_MODE) or None,
+        api_key=_get_str(KEY_API),
+        base_url=_get_str(KEY_BASE_URL),
+        default_model=_get_str(KEY_DEFAULT_MODEL),
+        default_mode=_get_str(KEY_DEFAULT_MODE),
     )
 
 
 def save_config(cfg: Config) -> Path:
-    """Save the given Config object to a TOML file.
+    """Persist the given config to TOML atomically with correct quoting.
 
-    Creates the config directory if necessary.
-    Sets secure permissions on Unix (700 for dir, 600 for file).
-    Escapes backslashes/quotes to preserve TOML validity.
+    - Creates the config directory if necessary.
+    - Uses _dump_toml to ensure strings are quoted (valid TOML).
+    - Writes via _atomic_write_text to prevent partial files.
+    - Sets secure permissions on Unix (700 dir, 600 file).
 
     Args:
         cfg (Config): Config values to save.
@@ -128,19 +187,19 @@ def save_config(cfg: Config) -> Path:
     except Exception:
         pass
 
-    lines = []
-    if cfg.api_key:
-        lines.append(f'{KEY_API} = "{_escape(cfg.api_key)}"')
-    if cfg.base_url:
-        lines.append(f'{KEY_BASE_URL} = "{_escape(cfg.base_url)}"')
-    if cfg.default_model:
-        lines.append(f"{KEY_DEFAULT_MODEL} = {_escape(cfg.default_model)}")
-    if cfg.default_mode:
-        lines.append(f"{KEY_DEFAULT_MODE} = {_escape(cfg.default_mode)}")
+    # Only include keys that are not None
+    data: dict[str, Any] = {}
+    if cfg.api_key is not None:
+        data[KEY_API] = cfg.api_key
+    if cfg.base_url is not None:
+        data[KEY_BASE_URL] = cfg.base_url
+    if cfg.default_model is not None:
+        data[KEY_DEFAULT_MODEL] = cfg.default_model
+    if cfg.default_mode is not None:
+        data[KEY_DEFAULT_MODE] = cfg.default_mode
 
-    content = "\n".join(lines) + ("\n" if lines else "")
     p = config_path()
-    p.write_text(content, encoding="utf-8")
+    _atomic_write_text(p, _dump_toml(data))
 
     try:
         if not sys.platform.startswith("win"):
@@ -149,6 +208,33 @@ def save_config(cfg: Config) -> Path:
         pass
 
     return p
+
+
+def _toml_escape(s: str) -> str:
+    """Escape a Python string for TOML basic strings."""
+    out = []
+    for ch in s:
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif ch == "\b":
+            out.append("\\b")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\f":
+            out.append("\\f")
+        elif ch == "\r":
+            out.append("\\r")
+        else:
+            # Escape any remaining control chars < 0x20
+            if ord(ch) < 0x20:
+                out.append(f"\\u{ord(ch):04X}")
+            else:
+                out.append(ch)
+    return "".join(out)
 
 
 def update_config(**kwargs: Optional[str]) -> Path:

--- a/tests/pkg_cgpt/test_cli.py
+++ b/tests/pkg_cgpt/test_cli.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner, Result
 from pytest import MonkeyPatch
 
 from cgpt.cli import main
-from cgpt.config import config_path
+from cgpt.config import config_path, update_config
 
 
 CFG_SUBPATH: Final[str] = "cgpt/config.toml"
@@ -107,3 +107,37 @@ def test_set_model_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
 
     cfg_text: str = _read_cfg(tmp_path)
     assert "default_model = gpt-5" in cfg_text
+
+
+def test_set_mode_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """`cgpt set --mode responses` writes only `default_mode`."""
+    _set_sandbox_config_home(tmp_path, monkeypatch)
+
+    runner: CliRunner = CliRunner()
+    result: Result = runner.invoke(main, ["set", "--mode", "responses"])
+
+    assert result.exit_code == 0, result.output
+    cfg_text: str = _read_cfg(tmp_path)
+    assert "default_mode = responses" in cfg_text
+
+
+def test_set_both_and_preserve_existing(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Setting both options updates them and preserves other existing keys."""
+    _set_sandbox_config_home(tmp_path, monkeypatch)
+
+    # Prepopulate another field to ensure it is preserved on update
+    update_config(api_key="sk-xyz")
+
+    runner: CliRunner = CliRunner()
+    result: Result = runner.invoke(
+        main,
+        ["set", "--model", "gpt-4o-mini", "--mode", "chat"],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg_text: str = _read_cfg(tmp_path)
+    assert 'api_key = "sk-xyz"' in cfg_text
+    assert "default_model = gpt-4o-mini" in cfg_text
+    assert "default_mode = chat" in cfg_text

--- a/tests/pkg_cgpt/test_cli.py
+++ b/tests/pkg_cgpt/test_cli.py
@@ -106,7 +106,7 @@ def test_set_model_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     assert result.exit_code == 0, result.output
 
     cfg_text: str = _read_cfg(tmp_path)
-    assert "default_model = gpt-5" in cfg_text
+    assert 'default_model = "gpt-5"' in cfg_text
 
 
 def test_set_mode_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -118,7 +118,7 @@ def test_set_mode_only(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
 
     assert result.exit_code == 0, result.output
     cfg_text: str = _read_cfg(tmp_path)
-    assert "default_mode = responses" in cfg_text
+    assert 'default_mode = "responses"' in cfg_text
 
 
 def test_set_both_and_preserve_existing(
@@ -139,8 +139,8 @@ def test_set_both_and_preserve_existing(
     assert result.exit_code == 0, result.output
     cfg_text: str = _read_cfg(tmp_path)
     assert 'api_key = "sk-xyz"' in cfg_text
-    assert "default_model = gpt-4o-mini" in cfg_text
-    assert "default_mode = chat" in cfg_text
+    assert 'default_model = "gpt-4o-mini"' in cfg_text
+    assert 'default_mode = "chat"' in cfg_text
 
 
 def test_set_requires_at_least_one_option(

--- a/tests/pkg_cgpt/test_cli.py
+++ b/tests/pkg_cgpt/test_cli.py
@@ -141,3 +141,16 @@ def test_set_both_and_preserve_existing(
     assert 'api_key = "sk-xyz"' in cfg_text
     assert "default_model = gpt-4o-mini" in cfg_text
     assert "default_mode = chat" in cfg_text
+
+
+def test_set_requires_at_least_one_option(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Calling `cgpt set` with no options should raise a usage error."""
+    _set_sandbox_config_home(tmp_path, monkeypatch)
+
+    runner: CliRunner = CliRunner()
+    result: Result = runner.invoke(main, ["set"])
+
+    assert result.exit_code != 0
+    assert "at least one option" in result.output.lower()


### PR DESCRIPTION
### Summary

Adds support for setting and persisting a default model and interaction mode. Introduces a new `cgpt set` subcommand and extends config read/write utilities to handle `default_model` and `default_mode`.

### Why

So users can choose a preferred model and whether `cgpt` runs in chat or responses mode by default—without retyping flags each time.

### What changed

* **Config**

  * Extended `Config` with `default_model` and `default_mode`.
  * `load_config()` / `save_config()` updated to read/write new fields.
  * Added `_normalize_str()` to coerce empty strings to `None`.
  * Added `update_config()` to safely merge & persist only provided fields.
* **CLI**

  * New `cgpt set` subcommand:

    * `--model <name>` to set `default_model`.
    * `--mode {responses,chat}` to set `default_mode` (validated).
    * Errors when invoked without at least one option.
* **Docs**

  * README now documents `cgpt set` with examples and a sample `config.toml`.
  * Mentions `cgpt where` for locating the active config file.
* **Tests**

  * Added sandboxed config path constant for tests.
  * Tests for:

    * `cgpt set --model gpt-5` writes `default_model`.
    * `cgpt set --mode responses` writes `default_mode`.
    * Combined `--model` + `--mode` updates both while preserving existing keys (e.g., `api_key`).
    * Usage error when called with no options.

### Usage

```bash
# set default model
cgpt set --model gpt-5

# set default mode to responses (or chat)
cgpt set --mode responses

# set both at once
cgpt set --model gpt-5 --mode chat

# see where config is stored
cgpt where
```

Example `~/.config/cgpt/config.toml`:

```toml
api_key = "sk-***"
default_model = "gpt-5"
default_mode = "responses"
```

### Backward compatibility

* No breaking changes. If the new fields are absent, defaults remain unchanged and behavior matches prior versions.

### Linked issue

* Closes #7.
